### PR TITLE
Fix JS execution bypass in safeResponse.js

### DIFF
--- a/safeResponse.js
+++ b/safeResponse.js
@@ -14,7 +14,7 @@ safeResponse = function(){
 
             if (
                 currentAttr === "href" &&
-                /^(#|javascript[:])/gi.test(target.getAttribute("href"))
+                /^(#|\s*javascript[:])/i.test(target.getAttribute("href"))
             ) {
                 target.parentNode.removeChild(target);
             }


### PR DESCRIPTION
URLs may be surrounded by spaces. It should not be possible to bypass the sanitizer in this way.

I've encountered multiple add-on submissions as a reviewer at AMO. This repo seems to be the source of the problem, so I hope that this patch helps.